### PR TITLE
Adding backness regions for vowels

### DIFF
--- a/app/templates/front.html
+++ b/app/templates/front.html
@@ -863,24 +863,12 @@
           <tr>
             <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-0">lower</td>
             <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-1">mid</td>
-            <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">near-front</td>
+            <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">central</td>
             <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-3">rounded</td>
           </tr>
           <tr>
             <td class="clbox-label-empty"></td>
             <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-1">low</td>
-            <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">central</td>
-            <td class="clbox-label-empty"></td>
-          </tr>
-          <tr>
-            <td class="clbox-label-empty"></td>
-            <td class="clbox-label-empty"></td>
-            <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">near-back</td>
-            <td class="clbox-label-empty"></td>
-          </tr>
-          <tr>
-            <td class="clbox-label-empty"></td>
-            <td class="clbox-label-empty"></td>
             <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">back</td>
             <td class="clbox-label-empty"></td>
           </tr>

--- a/gen/out.html
+++ b/gen/out.html
@@ -768,24 +768,12 @@
       <tr>
         <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-0">lower</td>
         <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-1">mid</td>
-        <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">near-front</td>
+        <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">central</td>
         <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-3">rounded</td>
       </tr>
       <tr>
         <td class="clbox-label-empty"></td>
         <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-1">low</td>
-        <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">central</td>
-        <td class="clbox-label-empty"></td>
-      </tr>
-      <tr>
-        <td class="clbox-label-empty"></td>
-        <td class="clbox-label-empty"></td>
-        <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">near-back</td>
-        <td class="clbox-label-empty"></td>
-      </tr>
-      <tr>
-        <td class="clbox-label-empty"></td>
-        <td class="clbox-label-empty"></td>
         <td class="clbox-label" onclick="handleClboxLabel(this)"  type="clbox-label-2">back</td>
         <td class="clbox-label-empty"></td>
       </tr>

--- a/phonemes/vowels.json
+++ b/phonemes/vowels.json
@@ -5,6 +5,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -15,6 +16,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -25,6 +27,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -35,6 +38,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -45,6 +49,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -55,6 +60,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -65,6 +71,7 @@
         "height region": "low",
         "height offset": "lower",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -75,6 +82,7 @@
         "height region": "low",
         "height offset": "lower",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -85,6 +93,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -95,6 +104,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -105,6 +115,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -115,6 +126,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -125,6 +137,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -135,6 +148,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -145,6 +159,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -155,6 +170,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -165,6 +181,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -175,6 +192,7 @@
         "height region": "high",
         "height offset": "upper",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -185,6 +203,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -195,6 +214,7 @@
         "height region": "mid",
         "height offset": "upper",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -205,6 +225,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -215,6 +236,7 @@
         "height region": "mid",
         "height offset": "lower",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -225,6 +247,7 @@
         "height region": "low",
         "height offset": "lower",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -235,6 +258,7 @@
         "height region": "low",
         "height offset": "lower",
         "backness": "back",
+        "backness region": "back",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -245,6 +269,7 @@
         "height region": "high",
         "height offset": "lower",
         "backness": "near-front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -255,6 +280,7 @@
         "height region": "high",
         "height offset": "lower",
         "backness": "near-front",
+        "backness region": "front",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true
@@ -265,6 +291,7 @@
         "height region": "low",
         "height offset": "upper",
         "backness": "front",
+        "backness region": "front",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -275,6 +302,7 @@
         "height region": "low",
         "height offset": "upper",
         "backness": "central",
+        "backness region": "central",
         "roundedness": "unrounded",
         "voicing": "voiced",
         "producible": true
@@ -285,6 +313,7 @@
         "height region": "high",
         "height offset": "lower",
         "backness": "near-back",
+        "backness region": "back",
         "roundedness": "rounded",
         "voicing": "voiced",
         "producible": true

--- a/phonemes/vowels.py
+++ b/phonemes/vowels.py
@@ -46,6 +46,12 @@ BACKNESSES = [
     "back"
 ]
 
+BACKNESS_REGIONS = [
+    "front",
+    "central",
+    "back"
+]
+
 ROUNDEDNESSES = [
     "unrounded",
     "rounded"
@@ -64,7 +70,7 @@ HEADERS = {
 CLBOX_HEADERS = {
     "height": HEIGHT_REGIONS,
     "offset": HEIGHT_OFFSETS,
-    "backness": BACKNESSES,
+    "backness": BACKNESS_REGIONS,
     "roundedness": ROUNDEDNESSES,
 
     "word order": ["offset", "height", "backness", "roundedness"],
@@ -81,20 +87,32 @@ GLYPHS = utils.glyphs(data)
 # those properties
 # E.g. {"voiced":    ["b", "d", ...],
 #       "voiceless": ["p", "t", ...], ...}"""
-HEIGHT_DICT         = utils.enumerateProperty(data, "height")
-HEIGHT_REGION_DICT  = utils.enumerateProperty(data, "height region")
-HEIGHT_OFFSET_DICT  = utils.enumerateProperty(data, "height offset")
-BACKNESS_DICT       = utils.enumerateProperty(data, "backness")
-ROUNDEDNESS_DICT    = utils.enumerateProperty(data, "roundedness")
-VOICING_DICT        = utils.enumerateProperty(data, "voicing")
+HEIGHT_DICT             = utils.enumerateProperty(data, "height")
+HEIGHT_REGION_DICT      = utils.enumerateProperty(data, "height region")
+HEIGHT_OFFSET_DICT      = utils.enumerateProperty(data, "height offset")
+BACKNESS_DICT           = utils.enumerateProperty(data, "backness")
+BACKNESS_REGION_DICT    = utils.enumerateProperty(data, "backness region")
+ROUNDEDNESS_DICT        = utils.enumerateProperty(data, "roundedness")
+VOICING_DICT            = utils.enumerateProperty(data, "voicing")
 
 # Combine these dicts together
-CLASSES_DICT = {**HEIGHT_DICT,
-                **HEIGHT_REGION_DICT,
-                **HEIGHT_OFFSET_DICT,
-                **BACKNESS_DICT,
-                **ROUNDEDNESS_DICT,
-                **VOICING_DICT}
+# MAJOR BUG: CLASSES_DICT expects unique keys,
+# but is provided with non-unique keys (e.g. "low" is both a key in height, height region)
+# Which I believe leads to loss of data.
+# Must ensure that the "right" data is not lost
+# e.g. if two key/value pairs exist with a key of "low", one should be a superset of
+# the other -- we would like to keep the superset not the subset.
+# If I'm lucky then later keys will overwrite earlier ones, but this is not
+# something nice to rely on.
+CLASSES_DICT = {
+    **HEIGHT_DICT,
+    **HEIGHT_REGION_DICT,
+    **HEIGHT_OFFSET_DICT,
+    **BACKNESS_DICT,
+    **BACKNESS_REGION_DICT,
+    **ROUNDEDNESS_DICT,
+    **VOICING_DICT
+}
 
 def isVowel(s):
     """Returns true iff s is a vowel representable in this system"""


### PR DESCRIPTION
Vowels are now grouped more compactly in the class listing, while the vowel trapezoid remains unchanged.

There is a new bug (or potential of a bug, at least) in that CLASSES_DICT expects unique keys, but is provided duplicate keys, which will need to be addressed at some point.